### PR TITLE
v1.1.x - Introduce `async` functionality

### DIFF
--- a/valorant/caller.py
+++ b/valorant/caller.py
@@ -41,12 +41,12 @@ class WebCaller(object):
         self,
         m: t.Text,
         ep: t.Text,
-        escape_if: t.Tuple[int] = (),
+        escape_if: t.Tuple[int, ...] = (),
         params: t.Optional[t.Mapping] = None,
         route: t.Optional[t.Text] = False,
         **kw,
     ) -> t.Optional[t.Mapping[str, t.Any]]:
-        prefix = self.base.format(root=self.route if route else self.region)
+        prefix = self.base.format(root=route if route else self.region)
         url = prefix + self.eps[ep].format(**kw)
 
         r = self.sess.request(m, url, params=params)
@@ -54,6 +54,4 @@ class WebCaller(object):
         if r.status_code in escape_if:
             return None
 
-        r.raise_for_status()
-
-        return r.json()
+        return r.raise_for_status() or r.json()

--- a/valorant/client.py
+++ b/valorant/client.py
@@ -356,7 +356,7 @@ class Client(object):
         """
 
         r = self.handle.call(
-            "GET", "puuid", route=True, puuid=puuid, escape_if=(400, 404)
+            "GET", "puuid", route=route, puuid=puuid, escape_if=(400, 404)
         )
 
         return AccountDTO(r, self.handle) if r else None
@@ -383,7 +383,7 @@ class Client(object):
         r = self.handle.call(
             "GET",
             "game-name",
-            route=True,
+            route=route,
             name=vals[0],
             tag=vals[1],
             escape_if=(400, 404),


### PR DESCRIPTION
These changes aim to re-introduce asynchronous request functionality to **valorant.py**. The original implementation was naïve and still made blocking requests to the API.

This will add the `aiohttp` dependency, and while I did want to keep the library dependency free for as long as possible, this functionality is too crucial to ignore.

The `AsyncClient` and its components will be introduced in `v1.1.0`, and other working changes will be added to `v1.0.x` in the meantime. 

**Developement:**
+ [ ] Refactor `WebCaller` to be more resource efficent.
+ [ ] Create an `AioCaller` client using `aiohttp`.
    + [ ] Add asyncio loop support.
    + [ ] Add response `Retry-After` support.
+ [ ] ~~Provide async helper utilities?~~