### PR TITLE
Typo fix

### DIFF
--- a/valorant/local/client.py
+++ b/valorant/local/client.py
@@ -24,11 +24,11 @@ class LocalClient(object):
     :type region: str
     """
 
-    def __init__(self, reigon="na"):
-        if reigon not in Lex.REGIONS:
-            raise ValueError(f"'{reigon}' is not a supported reigon for LocalClient.")
+    def __init__(self, region="na"):
+        if region not in Lex.REGIONS:
+            raise ValueError(f"'{region}' is not a supported region for LocalClient.")
 
-        self.reigon = reigon
+        self.region = region
         self.lockfile = "".join(
             [os.getenv("LOCALAPPDATA"), r"\Riot Games\Riot Client\Config\lockfile"]
         )


### PR DESCRIPTION
I have corrected the typo in the for the region argument in the LocalClient class. 

The changes I made weren't covered by the unit tests so I tested them by hand.